### PR TITLE
Support envvar

### DIFF
--- a/anno3d/app.py
+++ b/anno3d/app.py
@@ -190,6 +190,43 @@ class ProjectCommand:
         raise RuntimeError("この関数は廃止されました put_cuboid_label を利用してください")
 
     @staticmethod
+    def put_cuboid_label(
+        project_id: str,
+        label_id: str,
+        ja_name: str,
+        en_name: str,
+        color: Tuple[int, int, int],
+        annofab_id: Optional[str] = env_annofab_user_id,
+        annofab_pass: Optional[str] = env_annofab_password,
+    ) -> None:
+        """
+        対象のプロジェクトにcuboidのlabelを追加・更新します。
+        Args:
+            annofab_id: AnnoFabのユーザID。指定が無い場合は環境変数`ANNOFAB_USER_ID`の値をを採用する
+            annofab_pass: AnnoFabのパスワード。指定が無い場合は環境変数`ANNOFAB_PASSWORD`の値をを採用する
+            project_id: 対象プロジェクト
+            label_id: 追加・更新するラベルのid
+            ja_name: 日本語名称
+            en_name: 　英語名称
+            color: ラベルの表示色。 "(R,G,B)"形式の文字列 R/G/Bは、それぞれ0〜255の整数値で指定する
+
+        Returns:
+
+        """
+        if not validate_annofab_credential(annofab_id, annofab_pass):
+            return
+        assert annofab_id is not None and annofab_pass is not None
+        # 数値に変換可能な場合は型がintに変わるので、strに明示的に変換する。
+        label_id = str(label_id)
+        validate_annofab_credential(annofab_id, annofab_pass)
+        client_loader = ClientLoader(annofab_id, annofab_pass)
+        with client_loader.open_api() as api:
+            labels = ProjectApi(api).put_cuboid_label(project_id, label_id, ja_name, en_name, color)
+            labels_json = Label.schema().dumps(labels, many=True, ensure_ascii=False, indent=2)
+            logger.info("Label(=%s) を作成・更新しました", label_id)
+            logger.info(labels_json)
+
+    @staticmethod
     def put_segment_label(
         project_id: str,
         label_id: str,
@@ -241,43 +278,6 @@ class ProjectCommand:
             labels = ProjectApi(api).put_segment_label(
                 project_id, label_id, ja_name, en_name, color, default_ignore, segment_kind=segment_type, layer=layer,
             )
-            labels_json = Label.schema().dumps(labels, many=True, ensure_ascii=False, indent=2)
-            logger.info("Label(=%s) を作成・更新しました", label_id)
-            logger.info(labels_json)
-
-    @staticmethod
-    def put_cuboid_label(
-        project_id: str,
-        label_id: str,
-        ja_name: str,
-        en_name: str,
-        color: Tuple[int, int, int],
-        annofab_id: Optional[str] = env_annofab_user_id,
-        annofab_pass: Optional[str] = env_annofab_password,
-    ) -> None:
-        """
-        対象のプロジェクトにcuboidのlabelを追加・更新します。
-        Args:
-            annofab_id: AnnoFabのユーザID。指定が無い場合は環境変数`ANNOFAB_USER_ID`の値をを採用する
-            annofab_pass: AnnoFabのパスワード。指定が無い場合は環境変数`ANNOFAB_PASSWORD`の値をを採用する
-            project_id: 対象プロジェクト
-            label_id: 追加・更新するラベルのid
-            ja_name: 日本語名称
-            en_name: 　英語名称
-            color: ラベルの表示色。 "(R,G,B)"形式の文字列 R/G/Bは、それぞれ0〜255の整数値で指定する
-
-        Returns:
-
-        """
-        if not validate_annofab_credential(annofab_id, annofab_pass):
-            return
-        assert annofab_id is not None and annofab_pass is not None
-        # 数値に変換可能な場合は型がintに変わるので、strに明示的に変換する。
-        label_id = str(label_id)
-        validate_annofab_credential(annofab_id, annofab_pass)
-        client_loader = ClientLoader(annofab_id, annofab_pass)
-        with client_loader.open_api() as api:
-            labels = ProjectApi(api).put_cuboid_label(project_id, label_id, ja_name, en_name, color)
             labels_json = Label.schema().dumps(labels, many=True, ensure_ascii=False, indent=2)
             logger.info("Label(=%s) を作成・更新しました", label_id)
             logger.info(labels_json)


### PR DESCRIPTION
close #38 

* `--annofab_id, `--annofab_pass`をオプショナルな引数にして、指定しない場合は環境変数`ANNOFAB_USER_ID`, `ANNOFAB_PASSWORD` を参照するようにした。
* `--label_id 0`のように整数に変換できる値を指定すると、`label_id`の型がintになってエラーが発生したので、型が必ずstrになるように変更した。