### PR TITLE
annofabapiのバージョンが0.39.0以上でも利用できるようにする

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-annofabapi = "^0.38.0"
+annofabapi = ">=0.38.0"
 dataclasses-json = "^0.4.2"
 fire = "^0.3.1"
 more-itertools = "^8.5.0"


### PR DESCRIPTION
annofabapiのバージョンが`0.39.0`以上でも利用できるようにする