### PR TITLE
拡張KITTI形式のドキュメントに`file_extension`の使用例を追加しました。

### DIFF
--- a/docs/user_guide/kitti_extension.md
+++ b/docs/user_guide/kitti_extension.md
@@ -66,7 +66,8 @@
     {
         "type": "kitti_image",
         "image_dir": "image_2", // カメラ画像ファイルが格納されているディレクトリの名前
-        "calib_dir": "calib" // image_2に紐づくキャリブレーション情報が格納されているディレクトリの名前。
+        "calib_dir": "calib", // image_2に紐づくキャリブレーション情報が格納されているディレクトリの名前。
+        "file_extension": "png" // カメラ画像ファイルの拡張子
     },
     {
         "type": "kitti_label",


### PR DESCRIPTION
`file_extension`の使用例を追加しました。