### PR TITLE
[project create] プロジェクト設定の「タスクの割当方法」を、画面からプロジェクトを作成したときの設定に合わせるようにしました。

### DIFF
--- a/anno3d/annofab/project.py
+++ b/anno3d/annofab/project.py
@@ -194,7 +194,7 @@ class ProjectApi:
             "status": "active",
             "input_data_type": "custom",
             "organization_name": organization_name,
-            "configuration": {"plugin_id": plugin_id,},
+            "configuration": {"plugin_id": plugin_id},
         }
 
         project: Dict[str, Any]


### PR DESCRIPTION
# 現在の動き
`project create`コマンドでプロジェクトを作成すると、プロジェクト設定の「タスクの割当方法」は「ランダム割当と選択割当」になっています。

画面からプロジェクトを作成すると、「タスクの割当方法」は「ランダム割当」です。

![image](https://user-images.githubusercontent.com/6350027/168729975-e90dee7a-c4c0-478b-824a-765bf4a5aeef.png)

## 変更内容
`project create`コマンドで作成されたプロジェクトの設定を、画面からプロジェクトを作成したときのプロジェクト設定に合わせるようにしました。
具体的には、「タスクの割当方法」は「ランダム割当と選択割当」から「ランダム割当」に変更しました。

## 参考
https://kurusugawajp.slack.com/archives/C0180H9RGCU/p1652284296093599