### PR TITLE
タスク作成処理を`initiateTasksGenerationAPI`から`putTask`APIを使うように変更しました。

### DIFF
--- a/anno3d/annofab/task.py
+++ b/anno3d/annofab/task.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional
+from typing import Collection, List, Optional
 
 from annofabapi import AnnofabApi
 from annofabapi import models as afm
@@ -37,7 +37,7 @@ class TaskApi:
 
         return self._decode_task(result)
 
-    def put_task(self, task_id: str, input_data_ids: List[str]) -> Task:
+    def put_task(self, task_id: str, input_data_ids: Collection[str]) -> Task:
         client = self._client
         project_id = self._project_id
         result, _ = client.put_task(project_id, task_id, request_body={"input_data_id_list": input_data_ids})


### PR DESCRIPTION
タスク作成の処理を`initiateTasksGeneration`APIから`putTask`APIを使うように変更しました。
理由は以下の通りです。
* タスク作成処理が少ない（おおよそ200件以下）場合は、putTask APIの方が速い
* `initiateTasksGeneration` APIでは、タスク作成に失敗した際のエラーが分かりづらい

