### PR TITLE
タスクを作成する場合は、`--task_id_prefix`を必須にしました。

### DIFF
--- a/anno3d/app.py
+++ b/anno3d/app.py
@@ -98,6 +98,16 @@ def validate_aws_credentail() -> bool:
     return result
 
 
+def validate_task_id_prefix(task_id_prefix: str, upload_kind: UploadKind) -> bool:
+    if upload_kind in [UploadKind.CREATE_TASK, UploadKind.CREATE_ANNOTATION]:
+        if task_id_prefix == "":
+            print(
+                "'--upload_kind'の値が`task`または'annotation'の場合は、'--task_id_prefix'を指定してください。", file=sys.stderr,
+            )
+            return False
+    return True
+
+
 class Sandbox:
     """ sandboxの再現 """
 
@@ -667,6 +677,10 @@ class ProjectCommand:
         if not validate_annofab_credential(annofab_id, annofab_pass):
             return
 
+        enum_upload_kind = _decode_enum(UploadKind, upload_kind)
+        if not validate_task_id_prefix(task_id_prefix, enum_upload_kind):
+            return
+
         assert annofab_id is not None and annofab_pass is not None
         client_loader = ClientLoader(annofab_id, annofab_pass, annofab_endpoint)
         with client_loader.open_api() as api:
@@ -680,7 +694,7 @@ class ProjectCommand:
                 camera_horizontal_fov=_decode_enum(CameraHorizontalFovKind, camera_horizontal_fov),
                 sensor_height=sensor_height,
                 task_id_prefix=task_id_prefix,
-                kind=_decode_enum(UploadKind, upload_kind),
+                kind=enum_upload_kind,
             )
             scene_uploader.upload_from_path(Path(scene_path), uploader_input)
 
@@ -732,6 +746,11 @@ class ProjectCommand:
         assert annofab_id is not None and annofab_pass is not None
         if not validate_aws_credentail():
             return
+
+        enum_upload_kind = _decode_enum(UploadKind, upload_kind)
+        if not validate_task_id_prefix(task_id_prefix, enum_upload_kind):
+            return
+
         client_loader = ClientLoader(annofab_id, annofab_pass, annofab_endpoint)
         with client_loader.open_api() as api:
             uploader = SceneUploader(
@@ -744,7 +763,7 @@ class ProjectCommand:
                 camera_horizontal_fov=_decode_enum(CameraHorizontalFovKind, camera_horizontal_fov),
                 sensor_height=sensor_height,
                 task_id_prefix=task_id_prefix,
-                kind=_decode_enum(UploadKind, upload_kind),
+                kind=enum_upload_kind,
             )
             uploader.upload_from_path(Path(scene_path), uploader_input)
 


### PR DESCRIPTION
関連issue #76 

タスクを作成する場合（`--upload_kind`が`task`または`annotation`）、`--task_id_prefix`を指定しないと空文字のタスクIDのタスクを生成しようとして、エラーが発生します。
これを避けるために、タスクを作成する場合は`--task_id_prefix`を必須にしました。
