### PR TITLE
補助情報の種類を「カスタム」ではなく適切な値にする

### DIFF
--- a/anno3d/annofab/uploader.py
+++ b/anno3d/annofab/uploader.py
@@ -66,7 +66,7 @@ class Uploader(abc.ABC):
         input_data_id: str,
         supplementary_id: str,
         file: Path,
-        supplementary_data_type: Literal["custom", "image", "text"] = "custom",
+        supplementary_data_type: Literal["custom", "image", "text"],
     ) -> str:
         path = self.upload_tempdata(file)
         body = {

--- a/anno3d/app.py
+++ b/anno3d/app.py
@@ -160,7 +160,7 @@ class Sandbox:
                     data_id = data_id_prefix + velo_file.name
                     uploader.upload_input_data(data_id, velo_file)
                     supp_data = create_frame_meta(tempdir, data_id, 0, sensor_height)
-                    uploader.upload_supplementary(data_id, supp_data.data_id, supp_data.path)
+                    uploader.upload_supplementary(data_id, supp_data.data_id, supp_data.path, supp_data.data_type)
                     logger.info("uploaded: %s", velo_file)
 
 

--- a/anno3d/simple_data_uploader.py
+++ b/anno3d/simple_data_uploader.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class SupplementaryData:
     data_id: str
     path: Path
-    data_type: Literal["custom", "image", "text"] = "custom"
+    data_type: Literal["custom", "image", "text"]
 
 
 def create_frame_meta(


### PR DESCRIPTION
**解決されるissue**
fix #93

**目的**
入力データの補助情報の種類はcustom・image・textの3種類があるが、現状では補助情報種類はすべてcustomで登録されるようになっている。
そのため、補助情報の種類を以下の通り設定したい。

- カメラ画像: image
- カメラ画像に対応するキャリブレーションファイル: text
- メタ情報ファイル: text

そうすることにより、入力データ詳細画面でカメラ画像のプレビューが表示されるようになる。

**実装**
補助情報クラス（SupplementaryData）に補助情報の種類（data_type）を追加し、apiに渡すようにした。

**実行コマンド**
`anno3d project upload_kitti_data --annofab_id ${ANNO_ID} --annofab_pass ${ANNO_PASS} --project_id PROJECT_ID --kitti-dir KITTI_DIR [--force]`

以上のコマンドを実行後、annofab上で入力データの詳細を閲覧すると、プレビューが正しく表示される。

- 実装前
![preview1](https://user-images.githubusercontent.com/67464161/179722614-4015c0a7-7c87-46ce-9092-062f1fa1ed28.png)

- 実装後
![preview2](https://user-images.githubusercontent.com/67464161/179722626-bc8ffb28-a4d8-4b7e-bfe5-5030c4dd5d12.png)
