### PR TITLE
devcontainer用のDockerfileを更新：poetryのインストールで失敗しないようにした

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -106,20 +106,17 @@ RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         python3.8 \
-        python3-distutils \
+        python3.8-dev \
+        python3-pip \
     && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* \
     && ln -s $(which python3.8) /usr/local/bin/python
-
-# pip
-RUN set -x \
-    && curl -sSL https://bootstrap.pypa.io/get-pip.py | sudo -u vscode -i python - 
 ENV PIP_DEFAULT_TIMEOUT=100
 
 # poetry
 RUN set -x \
-    && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | sudo -u vscode -i python - \
-    && sudo -u vscode -i /home/vscode/.local/bin/poetry config virtualenvs.in-project true
-ENV PATH=$PATH:/home/vscode/.local/bin
+    && python -m pip install -U pip setuptools \
+    && pip install poetry \
+    && sudo -u vscode -i poetry config virtualenvs.in-project true
 
 # fix poetry issue (see: https://github.com/python-poetry/poetry/issues/221)
 RUN set -x \


### PR DESCRIPTION
# 概要
現状のDockerfileだと、poetryのインストールで以下のエラーが発生したため、修正した。

```
The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
```

以下、実行ログ。

```
 => ERROR [13/15] RUN set -x     && curl -sSL https://raw.githubuserconte  1.3s
------                                                                          
 > [13/15] RUN set -x     && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | sudo -u vscode -i python -     && sudo -u vscode -i /home/vscode/.local/bin/poetry config virtualenvs.in-project true:
#0 0.439 + curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py
#0 0.439 + sudo -u vscode -i python -
#0 1.149 The canonical source for Poetry's installation script is now https://install.python-poetry.org. Please update your usage to reflect this.
#0 1.149 Retrieving Poetry metadata
#0 1.149 
#0 1.149 # Welcome to Poetry!
#0 1.149 
#0 1.149 This will download and install the latest version of Poetry,
#0 1.149 a dependency and package manager for Python.
#0 1.149 
#0 1.149 It will add the `poetry` command to Poetry's bin directory, located at:
#0 1.149 
#0 1.149 /home/vscode/.local/bin
#0 1.149 
#0 1.149 You can uninstall at any time by executing this script with the --uninstall option,
#0 1.149 and these changes will be reverted.
#0 1.149 
#0 1.149 Installing Poetry (1.1.14)
#0 1.149 Installing Poetry (1.1.14): Creating environment
#0 1.149 The virtual environment was not created successfully because ensurepip is not
#0 1.149 available.  On Debian/Ubuntu systems, you need to install the python3-venv
#0 1.149 package using the following command.
#0 1.149 
#0 1.149     apt-get install python3-venv
#0 1.149 
#0 1.149 You may need to use sudo with that command.  After installing the python3-venv
#0 1.149 package, recreate your virtual environment.
#0 1.149 
#0 1.149 Failing command: ['/home/vscode/.local/share/pypoetry/venv/bin/python', '-Im', 'ensurepip', '--upgrade', '--default-pip']
#0 1.149 
------
error: failed to solve: executor failed running [/bin/sh -c set -x     && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | sudo -u vscode -i python -     && sudo -u vscode -i /home/vscode/.local/bin/poetry config virtualenvs.in-project true]: exit code: 1
[2363 ms] Error: Command failed: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /home/vagrant/Documents/annofab-3dpc-editor-cli/.devcontainer/Dockerfile -t vsc-annofab-3dpc-editor-cli-a41bca73be73e249511d7329c1fe897a --target devcontainer --build-arg COMPOSE_VERSION=1.27.4 /home/vagrant/Documents/annofab-3dpc-editor-cli/.devcontainer
[2363 ms]     at GR (/home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js:240:1436)
[2364 ms]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[2364 ms]     at async Hu (/home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js:239:2796)
[2364 ms]     at async tb (/home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js:239:1779)
[2364 ms]     at async QR (/home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js:245:2006)
[2364 ms]     at async cb (/home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js:245:3110)
[2364 ms]     at async i_ (/home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js:245:13194)
[2364 ms]     at async n_ (/home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js:245:12950)
[2370 ms] Exit code 1
[2375 ms] Command failed: /usr/share/code/code /home/vagrant/.vscode/extensions/ms-vscode-remote.remote-containers-0.241.3/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /home/vagrant/.config/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --workspace-folder /home/vagrant/Documents/annofab-3dpc-editor-cli --workspace-mount-consistency cached --id-label devcontainer.local_folder=/home/vagrant/Documents/annofab-3dpc-editor-cli --log-level debug --log-format json --config /home/vagrant/Documents/annofab-3dpc-editor-cli/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root true
[2375 ms] Exit code 1
```

