### PR TITLE
ReadTheDocsのビルド失敗に対応する

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 python:
-  version: 3.10
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==5.2.3
+sphinx==5.3.0
 pydata-sphinx-theme==0.9.0
-recommonmark=="0.7.1"
+myst-parser==0.18.1


### PR DESCRIPTION
ReadTheDocsの以下のビルドエラーに対応しました。
<img width="426" alt="image" src="https://user-images.githubusercontent.com/6350027/198502779-13cf079c-a6f7-4a14-a153-440c8ff3119e.png">

https://readthedocs.org/projects/annofab-3dpc-editor-cli/builds/18444179/