### PR TITLE
ドキュメントのヘッダーにGitHubアイコンを追加する

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,3 +56,9 @@ html_theme = "pydata_sphinx_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+
+html_theme_options = {
+    "github_url": "https://github.com/kurusugawa-computer/annofab-3dpc-editor-cli",
+    "footer_items": [],  # footerは重要な情報が表示されないので、footerを空にする
+}


### PR DESCRIPTION
* ヘッダにGitHubアイコンを追加
    * GitHubリポジトリに簡単にアクセス
* フッターをなくす

![image](https://user-images.githubusercontent.com/6350027/198979181-e1a10c05-83e4-486c-985a-bc6f9fe02e00.png)
