### PR TITLE
RGB付き点群データの登録に対応

### DIFF
--- a/anno3d/file_paths_loader.py
+++ b/anno3d/file_paths_loader.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
-from anno3d.kitti.scene_uploader import Defaults
 from anno3d.model.file_paths import FilePaths, FrameKey, FrameKind, ImagePaths
 from anno3d.model.scene import Scene
 
@@ -40,26 +39,24 @@ class FilePathsLoader:
 
 
 class ScenePathsLoader:
-    def __init__(self, scene_path: Path):
-        self.scene_path = scene_path
+    """コンストラクタに渡されたSceneを元にFilePathsを生成する"""
+
+    def __init__(self, scene: Scene, scene_dir: Path):
+        """
+
+        Args:
+            scene: 対象のscene
+            scene_dir:  sceneの元になったscene.metaファイルの存在するディレクトリのパス
+        """
+        self.scene = scene
+        self.scene_dir = scene_dir
 
     def load(self) -> List[FilePaths]:
         """
         Annofab点群形式（KITTIベース）のファイルを読み込む.
-
-        Args:
-            scene_path: 読み込み対象パス。　以下の何れかとなる
-                         * scene.metaファイルのパス
-                         * scene.metaファイルの存在するディレクトリのパス
-                         * scene.metaが存在しないアップロード対象ディレクトリのパス
-                             * "velodyne/image_2/calib/label_2" のディレクトリがあるという前提で、読み込みを行う
         """
-        file = self.scene_path
-        if self.scene_path.is_dir():
-            file = self.scene_path / Defaults.scene_meta_file
-
-        scene_dir = file.parent
-        scene = Scene.decode_path(file) if file.is_file() else Scene.default_scene(self.scene_path)
+        scene_dir = self.scene_dir
+        scene = self.scene
 
         def scene_to_paths(frame_id: str) -> FilePaths:
             images = [

--- a/anno3d/kitti/scene_uploader.py
+++ b/anno3d/kitti/scene_uploader.py
@@ -27,6 +27,7 @@ from anno3d.annofab.uploader import Uploader
 from anno3d.kitti.calib import read_calibration, transform_labels_into_lidar_coordinates
 from anno3d.kitti.camera_horizontal_fov_provider import CameraHorizontalFovKind
 from anno3d.model.file_paths import FilePaths, FrameKey, ImagePaths, LabelPaths
+from anno3d.model.frame import PcdFormat
 from anno3d.model.kitti_label import KittiLabel
 from anno3d.model.scene import Defaults, Scene
 from anno3d.simple_data_uploader import SupplementaryData, upload_async
@@ -236,6 +237,7 @@ class SceneUploader:
         paths: FilePaths,
         camera_horizontal_fov: CameraHorizontalFovKind,
         sensor_height: Optional[float],
+        pcd_format: PcdFormat,
     ) -> Tuple[str, List[SupplementaryData]]:
         async def run() -> Tuple[str, List[SupplementaryData]]:
             return await upload_async(
@@ -246,6 +248,7 @@ class SceneUploader:
                 camera_horizontal_fov,
                 fallback_horizontal_fov=None,
                 sensor_height=sensor_height,
+                pcd_format=pcd_format,
             )
 
         if self._sem is not None:
@@ -272,6 +275,7 @@ class SceneUploader:
                 paths,
                 uploader_input.camera_horizontal_fov,
                 uploader_input.sensor_height,
+                PcdFormat(scene.velodyne.format),
             )
             for paths in pathss
         ]

--- a/anno3d/model/frame.py
+++ b/anno3d/model/frame.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Literal
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -7,10 +8,21 @@ from anno3d.model.common import Vector3, camelcase
 
 @camelcase
 @dataclass(frozen=True)
+class PcdFormat(DataClassJsonMixin):
+    """
+    本質的には xyziとxyzirgbは別の型だが、今の定義は統一して表現できるので同居させている
+    """
+
+    format: Literal["xyzi", "xyzirgb"]
+
+
+@camelcase
+@dataclass(frozen=True)
 class PointCloudMetaData(DataClassJsonMixin):
     is_rightHand_system: bool
     up_vector: Vector3
     sensor_height: float
+    format: PcdFormat
 
 
 @camelcase
@@ -27,3 +39,4 @@ class FrameMetaData(DataClassJsonMixin):
 
     points: PointCloudMetaData
     images: ImagesMetaData
+    version: Literal["2"] = "2"

--- a/anno3d/model/scene.py
+++ b/anno3d/model/scene.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import ClassVar, List, Optional, Type, cast
+from typing import ClassVar, List, Literal, Optional, Type, cast
 
 from dataclasses_json import DataClassJsonMixin
 from more_itertools import first_true
@@ -15,6 +15,7 @@ class Series(DataClassJsonMixin):
 @dataclass(frozen=True)
 class KittiVelodyneSeries(Series):
     velodyne_dir: str
+    format: Literal["xyzi", "xyzirgb"] = "xyzi"
     type: str = "kitti_velodyne"
     type_value: ClassVar[str] = "kitti_velodyne"
 
@@ -107,6 +108,8 @@ class Scene(DataClassJsonMixin):
         )
         if velodyne is None:
             raise RuntimeError("sceneにkitti_velodyneが含まれていません")
+        if velodyne.format not in ["xyzi", "xyzirgb"]:
+            raise RuntimeError(f"kitti_velodyneのformatはxyziかxyzirgbである必要がありますが、{velodyne.format}が指定されています")
 
         def convert_path(path: str) -> str:
             return (scene_dir / path).as_posix()

--- a/docs/user_guide/annofab_point_cloud_format.md
+++ b/docs/user_guide/annofab_point_cloud_format.md
@@ -60,7 +60,8 @@
   "serieses": [
     {
         "type": "kitti_velodyne",
-        "velodyne_dir": "velodyne"  // 点群データが格納されているディレクトリの名前
+        "velodyne_dir": "velodyne",  // 点群データが格納されているディレクトリの名前
+        "format": "xyzi" // 点群データのフォーマット。"xyzi" or "xyzirgb"。 省略時は"xyzi"
     },
     {
         "type": "kitti_image",
@@ -108,7 +109,8 @@ scene0/
   "serieses": [
     {
         "type": "kitti_velodyne",
-        "velodyne_dir": "velodyne"  // 点群データが格納されているディレクトリの名前
+        "velodyne_dir": "velodyne",  // 点群データが格納されているディレクトリの名前
+        "format": "xyzi" // 点群データのフォーマット。"xyzi" or "xyzirgb"。 省略時は"xyzi"
     },
     {
         "type": "kitti_image",
@@ -179,6 +181,43 @@ scene0/
 ```
 
 
+## format
+
+### xyzi
+
+デフォルトのフォーマットです。
+kittiの点群データと同じとなります。
+
+点群データファイルには、ヘッダなどは無く、頂点情報のみで構成された16 * 頂点数\[Byte]のファイルです。
+以下のフォーマットで構成されています。
+
+```
+<pcd>   = <point>*
+<point> = <x><y><z><i>
+<x>     = x座標（32bit float）
+<y>     = y座標（32bit float）
+<z>     = z座標（32bit float）
+<i>     = 反射強度（32bit float, 0.0～1.0に正規化）
+```
+
+### xyzirgb
+
+xyziに色情報を加えた形式です。
+
+点群データファイルには、ヘッダなどは無く、頂点情報のみで構成された28 * 頂点数\[Byte]のファイルです。
+以下のフォーマットで構成されています。
+
+```
+<pcd>   = <point>*
+<point> = <x><y><z><i><r><g><b>
+<x>     = x座標（32bit float）
+<y>     = y座標（32bit float）
+<z>     = z座標（32bit float）
+<i>     = 反射強度（32bit float, 0.0～1.0に正規化）
+<r>     = 色情報 赤（32bit float, 0.0～255.0に正規化）
+<g>     = 色情報 緑（32bit float, 0.0～255.0に正規化）
+<b>     = 色情報 青（32bit float, 0.0～255.0に正規化）
+```
 
 ## ラベルファイル
 ラベルファイルの15番目の要素に、Annofabの`annotation_id`を格納できます。

--- a/tests/model/test_scene.py
+++ b/tests/model/test_scene.py
@@ -134,7 +134,7 @@ def test_decode_scene_with_format():
 
 
 def test_decode_scene_with_invalid_format():
-    """formatが防いである場合に読み込みに失敗することのテスト"""
+    """formatが不正である場合に読み込みに失敗することのテスト"""
     json = """{
   "id_list": [  // nuScenes にならって文字列にする（not数値）
     "006497",


### PR DESCRIPTION
fix #126 

## 概要

* scene.metaのformatの指定が読み込めるように修正
* scene.metaのformat情報を元に、3d-editorのFrameMetadataを登録できるように修正
* ドキュメントにフォーマットの情報を追記
    * [buildされたドキュメント](https://annofab-3dpc-editor-cli.readthedocs.io/ja/feature-126_xyzirgb/user_guide/annofab_point_cloud_format.html) 

## 動作確認

kurusugawa-computer/annofab/#11134  に置いてあるファイルを使って動作の確認が出来ます。

```
ANNO_ID=xxx
ANNO_PASS=xxx
ANNO_PRJ=xxx
ANNOFAB_ENDPOINT=xxx
SCENE_PATH=path/to/scene.meta

poetry run python anno3d/app.py project upload_scene \
  --annofab_id ${ANNO_ID} \
  --annofab_pass ${ANNO_PASS} \
  --project_id ${ANNO_PRJ} \
  --frame_per_task 10 \
  --camera_horizontal_fov "calib" \
  --input_data_id_prefix "xyzirgb_cli" \
  --task_id_prefix "xyzirgb_cli" \
  --sensor_height 0 \
  --upload_kind task \
  --scene_path ${SCENE_PATH} \
  --force \
  --annofab_endpoint=${ANNOFAB_ENDPOINT}
```
