### PR TITLE
自動でpublishするためのGitHub Actionsを追加

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,25 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install poetry
+      run: |
+          python -m pip install "poetry==1.1.15"
+    - name: Publish
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        poetry config pypi-token.pypi $PYPI_TOKEN
+        poetry publish --build

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ poetry completions bash | sudo tee /etc/bash_completion.d/poetry.bash-completion
 ```
 
 ## PyPIへの公開
+[GitHubのReleases](https://github.com/kurusugawa-computer/annofab-3dpc-editor-cli/releases)からリリースを作成してください。
+GitHub Actionsにより自動でPyPIに公開されます。
+
+手動でPyPIに公開する場合は、以下のコマンドを実行してください。
 
 ```
 $ make publish


### PR DESCRIPTION


# やったこと
Repository Secretsに`PYPI_TOKEN`を追加
![image](https://github.com/kurusugawa-computer/annofab-3dpc-editor-cli/assets/6350027/67ae8089-def9-4872-ba8d-6be3d2464a1d)

# 補足
https://github.com/kurusugawa-computer/annofab-api-python-client/blob/main/.github/workflows/publish-to-pypi.yml を参考にしました。