### PR TITLE
ReadTheDocsのbuild errorを修正する

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,11 @@
 version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+    
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
no issue

# エラー内容
ReadTheDocsで以下のbuild errorが発生していた。

```
Config validation error in build.os. Value build not found.
```
https://readthedocs.org/projects/annofab-3dpc-editor-cli/builds/23149995/

原因と対策は https://qiita.com/CookieBox26/items/56fb0bcb86eb5f8bbfc3 参照

# 対応方法
上記のqiita記事通り、修正した
