### PR TITLE
`poetry-dynamic-versioning`を導入して、GitHubのバージョンタグからバージョンを動的に生成するようにしました。

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,14 +9,15 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install poetry
       run: |
-          python -m pip install "poetry==1.1.15"
+          python -m pip install "poetry==1.8.3" "poetry-dynamic-versioning==1.4"
+          poetry self add "poetry-dynamic-versioning[plugin]@1.4.0"
     - name: Publish
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: "3.12"
     - name: Install poetry
       run: |
-          python -m pip install "poetry==1.8.3" "poetry-dynamic-versioning==1.4"
+          python -m pip install "poetry==1.8.3"
           poetry self add "poetry-dynamic-versioning[plugin]@1.4.0"
     - name: Publish
       env:

--- a/README.md
+++ b/README.md
@@ -154,10 +154,13 @@ poetry completions bash | sudo tee /etc/bash_completion.d/poetry.bash-completion
 ## PyPIへの公開
 [GitHubのReleases](https://github.com/kurusugawa-computer/annofab-3dpc-editor-cli/releases)からリリースを作成してください。
 GitHub Actionsにより自動でPyPIに公開されます。
+バージョン情報は、`poetry build`時に[poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning)によって、Gitのバージョンタグから生成されます。
 
 手動でPyPIに公開する場合は、以下のコマンドを実行してください。
 
 ```
+# VSCode Dev Containersでは、`/usr/local/lib/python3.12/dist-packages/`にインストールしようとするため、`sudo`で実行する必要があります。
+$ sudo poetry self add "poetry-dynamic-versioning[plugin]@1.4.0"
 $ make publish
 ```
 

--- a/anno3d/__init__.py
+++ b/anno3d/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.0" # `poetry-dynamic-versioning`を使ってGitHubのバージョンタグを取得している。変更不要
+__version__ = "0.0.0"  # `poetry-dynamic-versioning`を使ってGitHubのバージョンタグを取得している。変更不要

--- a/anno3d/__init__.py
+++ b/anno3d/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.2a1"
+__version__ = "0.0.0" # `poetry-dynamic-versioning`を使ってGitHubのバージョンタグを取得している。変更不要

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ anno3d = "anno3d.app:main"
 
 [tool.poetry-dynamic-versioning]
 enable = true
-format = "{base}"
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "annofab-3dpc-editor-cli"
-version = "0.2.2a1"
+version = "0.0.0" # `poetry-dynamic-versioning`を使ってGitHubのバージョンタグを取得している。変更不要
 description = "Annofabの3次元プロジェクトを操作するためのCLIです。"
 authors = ["Kurusugawa Computer Inc."]
 repository="https://github.com/kurusugawa-computer/annofab-3dpc-editor-cli"
@@ -63,6 +63,10 @@ multi_line_output = 3
 [tool.poetry.scripts]
 anno3d = "anno3d.app:main"
 
+[tool.poetry-dynamic-versioning]
+enable = true
+format = "{base}"
+
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
# 動作確認
最新のバージョンタグが付与されているコミットと、`poetry build`したときのコミットが一致している状態にして、`poetry build`を実行しました。
そうしないと、`0.2.1.post41.dev0+c8aeccb`のようなバージョンになるためです。

して生成された`dist/annofab_3dpc_editor_cli-0.2.1.tar.gz`の中身に、最新のバージョン情報が格納されていることを確認しました。



```
$ git tag v9.9.9
$ poetry build
Building annofab-3dpc-editor-cli (9.9.9)
  - Building sdist
  - Built annofab_3dpc_editor_cli-9.9.9.tar.gz
  - Building wheel
  - Built annofab_3dpc_editor_cli-9.9.9-py3-none-any.whl
$ git tag -d v9.9.9
```

```
$ unzip -p dist/annofab_3dpc_editor_cli-9.9.9-py3-none-any.whl anno3d/__init__.py
__version__ = "9.9.9"  # `poetry-dynamic-versioning`を使ってGitHubのバージョンタグを取得している。変更不要


$ unzip -p dist/annofab_3dpc_editor_cli-9.9.9-py3-none-any.whl  annofab_3dpc_editor_cli-9.9.9.dist-info/METADATA | head -n 3
Metadata-Version: 2.1
Name: annofab-3dpc-editor-cli
Version: 9.9.9
```


`.github/workflows/publish-to-pypi.yml`の動作確認は実施していません。マージされてから、実際にリリースしてみて確認します。

