### PR TITLE
`--input_data_id_prefix`に数値を指定しても、`TypeError`が発生しないようにしました。

### DIFF
--- a/anno3d/simple_data_uploader.py
+++ b/anno3d/simple_data_uploader.py
@@ -174,7 +174,7 @@ def upload(
     sensor_height: Optional[float],
     pcd_format: PcdFormat,
 ) -> Tuple[str, List[SupplementaryData]]:
-    input_data_id_prefix = input_data_id_prefix + "_" if input_data_id_prefix else ""
+    input_data_id_prefix = f"{input_data_id_prefix}_" if input_data_id_prefix else ""
     input_data_id = uploader.upload_input_data(f"{input_data_id_prefix}{paths.key.id}", paths.pcd)
 
     with tempfile.TemporaryDirectory() as tempdir_str:
@@ -239,7 +239,7 @@ def create_kitti_files(
     sensor_height: Optional[float],
     pcd_format: PcdFormat,
 ) -> InputData:
-    input_data_id_prefix = input_data_id_prefix + "_" if input_data_id_prefix else ""
+    input_data_id_prefix = f"{input_data_id_prefix}_" if input_data_id_prefix else ""
     input_data_id = f"{input_data_id_prefix}{paths.key.id}".format(input_data_id_prefix, paths.key.id)
     input_data_dir = parent_dir / paths.key.id
     if input_data_dir.exists():


### PR DESCRIPTION
# 背景
`--input_data_id_prefix`に数値を指定すると、`TypeError`が発生しました。

```
$ poetry run anno3d project upload_scene --project_id ${PROJECT_ID}  --scene_path  tests/resources/kitti3dobj/training/  --upload_kind data --input_data_id_prefix 20241212

  File "/home/yuji/workspace/github.com/annofab-3dpc-editor-cli/anno3d/simple_data_uploader.py", line 177, in upload
    input_data_id_prefix = input_data_id_prefix + "_" if input_data_id_prefix else ""
                           ~~~~~~~~~~~~~~~~~~~~~^~~~~
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```

`app.py`では`input_data_id_prefix`の型を`str`にしていますが、Fireはint型に変換するため`TypeError`が発生しました。

```
@staticmethod
    def upload_scene(
        project_id: str,
        scene_path: str,
        input_data_id_prefix: str = "",
        task_id_prefix: str = "", ...):
        pass
 ```

https://github.com/google/python-fire/issues/453

# 対応方法
`+`演算子を使わずにf-stringで対応しました。
f-stringなら`input_data_id_prefix`の型がintでもエラーは発生しません。