### PR TITLE
`--scene_path`などパスを指定する引数に、`001`など数値とみなされるディレクトリ名を渡したときに`TypeError`が発生する問題を修正しました。

### DIFF
--- a/anno3d/app.py
+++ b/anno3d/app.py
@@ -593,7 +593,7 @@ class ProjectCommand:
     ) -> None:
         project = project_id
 
-        kitti_dir_path = Path(kitti_dir)
+        kitti_dir_path = Path(str(kitti_dir))
         loader = FilePathsLoader(kitti_dir_path, kitti_dir_path, kitti_dir_path)
         pathss = loader.load(None)[skip : (skip + size)]
         client_loader = ClientLoader(annofab_credential, annofab_endpoint)
@@ -712,7 +712,7 @@ class ProjectCommand:
                 task_id_prefix=task_id_prefix,
                 kind=enum_upload_kind,
             )
-            scene_uploader.upload_from_path(Path(scene_path), uploader_input)
+            scene_uploader.upload_from_path(Path(str(scene_path)), uploader_input)
 
     @staticmethod
     def upload_scene_to_s3(
@@ -787,7 +787,7 @@ class ProjectCommand:
                 task_id_prefix=task_id_prefix,
                 kind=enum_upload_kind,
             )
-            uploader.upload_from_path(Path(scene_path), uploader_input)
+            uploader.upload_from_path(Path(str(scene_path)), uploader_input)
 
 
 class LocalCommand:
@@ -826,8 +826,8 @@ class LocalCommand:
                            3dpc-editorは、この値を元に地面の高さを仮定する。 指定が無い場合はkittiのvelodyneの設置高を採用する
         Returns:
         """
-        kitti_dir_path = Path(kitti_dir)
-        output_dir_path = Path(output_dir)
+        kitti_dir_path = Path(str(kitti_dir))
+        output_dir_path = Path(str(output_dir))
         loader = FilePathsLoader(kitti_dir_path, kitti_dir_path, kitti_dir_path)
         pathss = loader.load(None)[skip : (skip + size)]
 
@@ -868,9 +868,9 @@ class LocalCommand:
                            3dpc-editorは、この値を元に地面の高さを仮定する。 指定が無い場合はkittiのvelodyneの設置高を採用する
         Returns:
         """
-        output_dir_path = Path(output_dir)
+        output_dir_path = Path(str(output_dir))
 
-        scene_path_ = Path(scene_path)
+        scene_path_ = Path(str(scene_path))
         file = scene_path_
         if scene_path_.is_dir():
             file = scene_path_ / Defaults.scene_meta_file


### PR DESCRIPTION
# 不具合の内容
`--scene_path`にはディレクトリ名を渡すこともできます。`999`というディレクトリ名があったので、` --scene_path 999`を指定したら、`TypeError`が発生しました。
原因は、`Path()`にintである値を渡したためです。

```
$  anno3d project upload_scene_to_s3 --project_id ${PROJECT_ID}  --scene_path 999 --s3_path foo --upload_kind data  --force
[2024-12-13 13:10:50,497] [1289583] [botocore.credentials] [INFO] Found credentials in shared credentials file: ~/.aws/credentials
Traceback (most recent call last):
  File "/home/yuji/.pyenv/versions/3.12.4/bin/anno3d", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/yuji/.pyenv/versions/3.12.4/lib/python3.12/site-packages/anno3d/app.py", line 912, in main
    fire.Fire(Command)
  File "/home/yuji/.pyenv/versions/3.12.4/lib/python3.12/site-packages/fire/core.py", line 138, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yuji/.pyenv/versions/3.12.4/lib/python3.12/site-packages/fire/core.py", line 463, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "/home/yuji/.pyenv/versions/3.12.4/lib/python3.12/site-packages/fire/core.py", line 672, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yuji/.pyenv/versions/3.12.4/lib/python3.12/site-packages/anno3d/app.py", line 790, in upload_scene_to_s3
    uploader.upload_from_path(Path(scene_path), uploader_input)
                              ^^^^^^^^^^^^^^^^
  File "/home/yuji/.pyenv/versions/3.12.4/lib/python3.12/pathlib.py", line 1162, in __init__
    super().__init__(*args)
  File "/home/yuji/.pyenv/versions/3.12.4/lib/python3.12/pathlib.py", line 373, in __init__
    raise TypeError(
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'int'
```

`Fire`は型ヒントを考慮せずに自動的に適切な型へ変換するため、今回のエラーが発生しました。
#154 と同じ状況です。

# 修正内容
`Path()`に渡す以下の引数について、`Path()`に渡す前に`str()`で文字列に変換するようにしました。

* `--scene_path`
* `--output_dir`
* `--kitti_dir`


# 補足
Fireの自動的な型変換による問題はまだ残っているかもしれません。
問題が発生したときに修正しようと思います。
