### PR TITLE
`project upload_scene_to_s3` : `--s3_path`に指定した値の末尾がスラッシュでないとき、末尾がスラッシュのとき同じ挙動になるようにしました。

### DIFF
--- a/anno3d/annofab/uploader.py
+++ b/anno3d/annofab/uploader.py
@@ -136,7 +136,10 @@ class S3Uploader(Uploader):
     def __init__(self, client: AnnofabApi, project: str, s3_path: str, force: bool = False):
         tmp = s3_path.split("/")
         self._s3_bucket = tmp[0]
-        self._s3_prefix_key = s3_path[len(self._s3_bucket + "/") :]
+        s3_prefix_key = s3_path[len(self._s3_bucket + "/") :]
+        if not s3_prefix_key.endswith("/"):
+            s3_prefix_key += "/"
+        self._s3_prefix_key = s3_prefix_key
         self._s3_client = boto3.client("s3")
         super().__init__(client=client, project=project, force=force)
 


### PR DESCRIPTION
# 背景

以下のコマンドを実行すると、S3にアップロードされるファイルは`fooscene01`というフォルダ配下に配置されます。

```
$ anno3d project upload_scene_to_s3 --project_id ${PROJECT_ID} --scene_path scene1/ --s3_path my-bucket/foo --upload_kind data
```

原因は、`--s3_path`に指定した値の末尾がスラッシュ`/`でないためです。
これ自体は問題ではありませんが、ユーザーは`foo/scene01`というフォルダに配置されることを期待していると思います。

# 修正内容
`--scene_path`の末尾がスラッシュでない場合は、末尾にスラッシュを付与したときと同じ挙動になるように変更しました。


# 動作確認
`upload_scene_to_s3`コマンドを実行して、AWS S3にアップロードされたファイルのキー（フォルダ構成）を見て、期待通りであることを確認しました。