### PR TITLE
`project upload_scene` : s3へのアップロードのtimeoutをなしにする

### DIFF
--- a/anno3d/annofab/uploader.py
+++ b/anno3d/annofab/uploader.py
@@ -123,7 +123,7 @@ class AnnofabStorageUploader(Uploader):
         with upload_file.open(mode="rb") as data:
             if content_type is None:
                 content_type = _get_content_type(upload_file)
-            requests.put(data_path.url, data, headers={"Content-Type": content_type}, timeout=None)
+            requests.put(data_path.url, data, headers={"Content-Type": content_type}, timeout=300)
 
         return data_path.path
 

--- a/anno3d/annofab/uploader.py
+++ b/anno3d/annofab/uploader.py
@@ -123,7 +123,7 @@ class AnnofabStorageUploader(Uploader):
         with upload_file.open(mode="rb") as data:
             if content_type is None:
                 content_type = _get_content_type(upload_file)
-            requests.put(data_path.url, data, headers={"Content-Type": content_type}, timeout=300)
+            requests.put(data_path.url, data, headers={"Content-Type": content_type}, timeout=600)
 
         return data_path.path
 

--- a/anno3d/annofab/uploader.py
+++ b/anno3d/annofab/uploader.py
@@ -123,7 +123,7 @@ class AnnofabStorageUploader(Uploader):
         with upload_file.open(mode="rb") as data:
             if content_type is None:
                 content_type = _get_content_type(upload_file)
-            requests.put(data_path.url, data, headers={"Content-Type": content_type}, timeout=30)
+            requests.put(data_path.url, data, headers={"Content-Type": content_type})
 
         return data_path.path
 

--- a/anno3d/annofab/uploader.py
+++ b/anno3d/annofab/uploader.py
@@ -123,7 +123,7 @@ class AnnofabStorageUploader(Uploader):
         with upload_file.open(mode="rb") as data:
             if content_type is None:
                 content_type = _get_content_type(upload_file)
-            requests.put(data_path.url, data, headers={"Content-Type": content_type})
+            requests.put(data_path.url, data, headers={"Content-Type": content_type}, timeout=None)
 
         return data_path.path
 


### PR DESCRIPTION
#171 に関連しています。

8～10MBの点群を自宅からアップロードする際、TimeoutErrorが頻発するので、`timeout`を指定しないようにしました。
暫定的な対応です。

この pull request がマージされた後で、リトライ処理を実装する予定です。
